### PR TITLE
Support monochrome bulbs and remove warning about set_rgbw()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,28 @@
-Python control for Mipow smart LED bulbs
-=========================================
+Python control for Mipow LED bulbs
+==================================
 
-A simple python API for [Mipow Smart](http://www.mipow.de/smart-home/46/mipow-playbulb-smart) Bluetooth LE lightbulbs
-Based on the work by Matthew Garret on [python-zengge](https://github.com/mjg59/python-zengge) 
-
+A simple Python API for controlling LED bulbs compatible from [Mipow](https://www.mipow.com/).
 
 Example use
 -----------
 
-This will connect and set the bulb to full red, no green and no blue.
+This will connect and set the bulb to full red, no green, no blue and 50% white
 ```
 import mipow
 
 bulb = mipow.mipow("00:21:4d:00:00:01")
 bulb.connect()
-bulb.set_rgb(255, 0, 0)
+bulb.set_rgb(0xff, 0x00, 0x00, 0x80)
 ```
 
-This will set the intensity of the warm white LEDs to 50%
+This will set the intensity of the white LEDs to 50%
 ```
 bulb.set_white(0x80)
 ```
 
-This will turn on the white LEDs at the same time as the colour LEDs (note that this may result in a small quantity of flickering during colour changes)
+Get a list of the current red, green, blue and white values
 ```
-bulb.set_rgbw(255, 255, 100, 255)
-```
-
-This will turn the bulb on
-```
-bulb.on()
-```
-
-This will turn the bulb off
-```
-bulb.off()
-```
-
-Get a list of the current red, green and blue values
-```
-(red, green, blue) = bulb.get_colour()
+(red, green, blue, white) = bulb.get_rgbw()
 ```
 
 Get the current white intensity
@@ -47,12 +30,9 @@ Get the current white intensity
 white = bulb.get_white()
 ```
 
-Get aboolean describing whether the bulb is on or off
-```
-on = bulb.get_on()
-```
+Check whether the bulb is monochrome
 
-Notes
------
-
-Note that this has been written against a specific bulb, and may misbehave on some other bulbs that speak a similar protocol. Please get in touch if you have a bulb that partially works with this code.
+```
+if bulb.mono:
+  print("Monochrome")
+```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ version = 0.1
 
 setup(
     name='mipow',
-    version=0.1,
+    version=0.3,
     author='Arttu Mahlakaarto',
     author_email='Arttu.mahlakaarto@gmail.com',
     url='http://github.com/amahlaka/python-mipow',


### PR DESCRIPTION
Add support for identifying monochrome bulbs, and remove the warning about
set_rgbw() - it seems to work fine on these bulbs.